### PR TITLE
Add support for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         rust: [nightly, beta, stable]
     steps:
       - uses: actions/checkout@v3
@@ -36,9 +36,10 @@ jobs:
           RUSTFLAGS: --cfg async_signal_force_pipe_impl
 
   msrv:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         # When updating this, the reminder to update the minimum supported
         # Rust version in Cargo.toml and .clippy.toml.
         rust: ['1.48']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,26 @@ categories = ["asynchronous", "concurrency", "os", "signal-handling"]
 exclude = ["/.*"]
 
 [dependencies]
-async-io = "1.12.0"
 cfg-if = "1.0.0"
 futures-core = "0.3.26"
+
+[target.'cfg(unix)'.dependencies]
+async-io = "1.12.0"
 futures-io = "0.3.26"
 libc = "0.2.139"
 signal-hook-registry = "1.4.0"
+
+[target.'cfg(windows)'.dependencies]
+async-lock = "2.7.0"
+atomic-waker = "1.1.1"
+slab = "0.4.8"
+windows-targets = "0.48.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 concurrent-queue = "2.2.0"
 
 [dev-dependencies]
+async-io = "1.12.0"
 futures-lite = "1.12.0"
 signal-hook = "0.3.14"
 

--- a/examples/print.rs
+++ b/examples/print.rs
@@ -7,6 +7,7 @@ use signal_hook::low_level;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     async_io::block_on(async {
         // Register the signals we want to receive.
+        #[cfg(unix)]
         let signals = Signals::new(&[
             Signal::Term,
             Signal::Quit,
@@ -17,6 +18,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Signal::Child,
             Signal::Cont,
         ])?;
+
+        #[cfg(windows)]
+        let signals = Signals::new(&[Signal::Int])?;
 
         // Loop over the signals.
         signals

--- a/generate_windows_bindings.rs
+++ b/generate_windows_bindings.rs
@@ -1,0 +1,21 @@
+#!/usr/bin/env rust-script
+
+//! Easy script for generating the bindings that we need to Windows.
+//! 
+//! ```cargo
+//! [dependencies]
+//! windows-bindgen = "0.49"
+//! ```
+
+use std::env;
+
+fn main() {
+    let apis = &[
+        "Windows.Win32.System.Console.SetConsoleCtrlHandler",
+        "Windows.Win32.System.Console.PHANDLER_ROUTINE",
+        "Windows.Win32.System.Console.CTRL_C_EVENT",
+        "Windows.Win32.Foundation::BOOL"
+    ];
+
+    println!("{}", windows_bindgen::standalone(apis));
+}

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,0 +1,105 @@
+//! A signal notifier that uses an asynchronous channel.
+//!
+//! This is only valid for Windows, where there are less strict signal handling
+//! requirements.
+
+use crate::Signal;
+
+use atomic_waker::AtomicWaker;
+
+use std::io;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+/// The notifier that uses an asynchronous channel.
+#[derive(Debug)]
+pub struct Notifier {
+    /// The pipe used to send signals.
+    pipe: Arc<Pipe>,
+}
+
+impl Notifier {
+    /// Create a new signal notifier.
+    pub(super) fn new() -> io::Result<Self> {
+        Ok(Self {
+            pipe: Arc::new(Pipe {
+                count: AtomicUsize::new(0),
+                waker: AtomicWaker::new(),
+            }),
+        })
+    }
+
+    /// Add a signal to the notifier.
+    ///
+    /// Returns a closure to be passed to signal-hook.
+    pub(super) fn add_signal(
+        &mut self,
+        _signal: Signal,
+    ) -> io::Result<impl Fn() + Send + Sync + 'static> {
+        let pipe = self.pipe.clone();
+        Ok(move || {
+            pipe.push();
+        })
+    }
+
+    /// Remove a signal from the notifier.
+    pub(super) fn remove_signal(&mut self, _signal: Signal) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Get the next signal.
+    pub(super) fn poll_next(&self, cx: &mut Context<'_>) -> Poll<io::Result<Signal>> {
+        let mut count = self.pipe.count.load(Ordering::SeqCst);
+        let mut registered = false;
+
+        loop {
+            // If the count is greater than zero, then we have a signal.
+            if count > 0 {
+                // Decrement the count.
+                let new_count = count - 1;
+                if let Err(new_count) = self.pipe.count.compare_exchange(
+                    count,
+                    new_count,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                ) {
+                    count = new_count;
+                    continue;
+                }
+
+                // Return the signal.
+                return Poll::Ready(Ok(Signal::Int));
+            }
+
+            // If the count is zero, then we need to wait for a signal.
+            if registered {
+                // We are already registered, so we need to wait for a signal.
+                return Poll::Pending;
+            } else {
+                registered = true;
+                self.pipe.waker.register(cx.waker());
+
+                // Try again.
+                count = self.pipe.count.load(Ordering::SeqCst);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Pipe {
+    /// The number of SIGINT signals received.
+    count: AtomicUsize,
+
+    /// The waker to wake up.
+    waker: AtomicWaker,
+}
+
+impl Pipe {
+    /// Add a signal to the notifier.
+    fn push(&self) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        self.waker.wake();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 //! This crate provides the [`Signals`] type, which can be used to listen for POSIX signals asynchronously.
 //! It can be seen as an asynchronous version of [`signal_hook::iterator::Signals`].
 //!
-//! As of the time of writing, this crate is `unix`-only.
-//!
 //! [`signal_hook::iterator::Signals`]: https://docs.rs/signal-hook/latest/signal_hook/iterator/struct.Signals.html
 //!
 //! # Implementation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! Note that the internal pipe has a limited capacity. Once it has reached capacity, additional
 //! signals will be dropped.
-//! 
+//!
 //! On Windows, a different implementation that only supports `SIGINT` is used. This implementation
 //! uses a channel to notify the user.
 //!
@@ -92,7 +92,6 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::fmt;
 use std::io;
-use std::os::raw::c_int;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -104,7 +103,7 @@ use std::os::unix::io::{AsFd, BorrowedFd};
 
 #[cfg(windows)]
 mod libc {
-    pub(crate) use super::c_int;
+    pub(crate) use std::os::raw::c_int;
 
     // Define these ourselves.
     // Copy-pasted from the libc crate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@
 //!
 //! Note that the internal pipe has a limited capacity. Once it has reached capacity, additional
 //! signals will be dropped.
+//! 
+//! On Windows, a different implementation that only supports `SIGINT` is used. This implementation
+//! uses a channel to notify the user.
 //!
 //! [`signal_hook_registry`]: https://crates.io/crates/signal-hook-registry
 //! [`async-io`]: https://crates.io/crates/async-io
@@ -48,8 +51,6 @@
 //! # }
 //! ```
 
-#![cfg(unix)]
-
 macro_rules! ready {
     ($e: expr) => {
         match $e {
@@ -66,25 +67,77 @@ cfg_if::cfg_if! {
     } else if #[cfg(any(target_os = "android", target_os = "linux"))] {
         mod signalfd;
         use signalfd as sys;
+    } else if #[cfg(windows)] {
+        mod channel;
+        use channel as sys;
     } else {
         mod pipe;
         use pipe as sys;
     }
 }
 
+cfg_if::cfg_if! {
+    if #[cfg(unix)] {
+        use signal_hook_registry as registry;
+    } else if #[cfg(windows)] {
+        mod windows_registry;
+        use windows_registry as registry;
+    }
+}
+
 use futures_core::stream::Stream;
-use signal_hook_registry::SigId;
+use registry::SigId;
 
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::fmt;
 use std::io;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::raw::c_int;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-#[cfg(not(async_signal_no_io_safety))]
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
+
+#[cfg(all(unix, not(async_signal_no_io_safety)))]
 use std::os::unix::io::{AsFd, BorrowedFd};
+
+#[cfg(windows)]
+mod libc {
+    pub(crate) use super::c_int;
+
+    // Define these ourselves.
+    // Copy-pasted from the libc crate
+    pub const SIGHUP: c_int = 1;
+    pub const SIGINT: c_int = 2;
+    pub const SIGQUIT: c_int = 3;
+    pub const SIGILL: c_int = 4;
+    pub const SIGTRAP: c_int = 5;
+    pub const SIGABRT: c_int = 6;
+    pub const SIGFPE: c_int = 8;
+    pub const SIGKILL: c_int = 9;
+    pub const SIGSEGV: c_int = 11;
+    pub const SIGPIPE: c_int = 13;
+    pub const SIGALRM: c_int = 14;
+    pub const SIGTERM: c_int = 15;
+    pub const SIGTTIN: c_int = 21;
+    pub const SIGTTOU: c_int = 22;
+    pub const SIGXCPU: c_int = 24;
+    pub const SIGXFSZ: c_int = 25;
+    pub const SIGVTALRM: c_int = 26;
+    pub const SIGPROF: c_int = 27;
+    pub const SIGWINCH: c_int = 28;
+    pub const SIGCHLD: c_int = 17;
+    pub const SIGBUS: c_int = 7;
+    pub const SIGUSR1: c_int = 10;
+    pub const SIGUSR2: c_int = 12;
+    pub const SIGCONT: c_int = 18;
+    pub const SIGSTOP: c_int = 19;
+    pub const SIGTSTP: c_int = 20;
+    pub const SIGURG: c_int = 23;
+    pub const SIGIO: c_int = 29;
+    pub const SIGSYS: c_int = 31;
+}
 
 macro_rules! define_signal_enum {
     (
@@ -117,6 +170,7 @@ macro_rules! define_signal_enum {
             }
 
             /// Parse a signal from its number.
+            #[cfg(unix)]
             fn from_number(number: libc::c_int) -> Option<Self> {
                 match number {
                     $(
@@ -216,7 +270,7 @@ pub struct Signals {
 impl Drop for Signals {
     fn drop(&mut self) {
         for signal in self.signal_ids.values() {
-            signal_hook_registry::unregister(*signal);
+            registry::unregister(*signal);
         }
     }
 }
@@ -283,7 +337,7 @@ impl Signals {
 
             let id = unsafe {
                 // SAFETY: Closure is guaranteed to be signal-safe.
-                signal_hook_registry::register(signal.number(), closure)?
+                registry::register(signal.number(), closure)?
             };
 
             // Add the signal ID to the map.
@@ -315,20 +369,21 @@ impl Signals {
             self.notifier.remove_signal(*signal)?;
 
             // Use `signal-hook-registry` to unregister the signal.
-            signal_hook_registry::unregister(id);
+            registry::unregister(id);
         }
 
         Ok(())
     }
 }
 
+#[cfg(unix)]
 impl AsRawFd for Signals {
     fn as_raw_fd(&self) -> RawFd {
         self.notifier.as_raw_fd()
     }
 }
 
-#[cfg(not(async_signal_no_io_safety))]
+#[cfg(all(unix, not(async_signal_no_io_safety)))]
 impl AsFd for Signals {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.notifier.as_fd()

--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -1,0 +1,158 @@
+//! Signal registration for Windows.
+//!
+//! Windows on its own does not have a concept of signals; signal handling is instead done by the
+//! Windows CRT, which Rust does not typically interact with. `signal-hook-registry` works by
+//! interfacing with the CRT, which I'd argue is somewhat of an anti-pattern in Rust. Instead,
+//! for this crate, let's take a look at the signals that Windows does have and how we can
+//! leverage them without the CRT.
+//!
+//! The six signals that Windows defines are SIGINT, SIGTERM, SIGABRT, SIGILL, SIGSEGV, and
+//! SIGFPE. The CRT will return an error if you try to use any other signals. Of these six, only
+//! SIGINT is usable for real life purposes.
+//!
+//! - SIGILL, SIGSEGV and SIGFPE are serious errors that are intended to crash the program. Users who
+//!   listen for this signals will need to often run raw C functions (`longjmp`, direct address
+//!   manipulation, etc etc) to accurately handle these signals. In other words, these aren't something
+//!   that can really be handled using our `async` strategy!
+//! - SIGABRT is internal to the CRT and is only raised when `libc::abort()` is called. This makes it
+//!   somewhat of a futile exercise to listen for it in Rust, since `std::process::abort()` will
+//!   not raise `SIGABRT` and will just abort the process directly.
+//! - SIGTERM is never actually raised by Windows outside of the `libc::raise()` function.
+//! - SIGINT corresponds to the `CTRL_C_EVENT` event handled by the `SetConsoleCtrlHandler` function.
+//!   This is probably also the only signal that is actually useful to listen for.
+//!
+//! Therefore, all we need to do to properly handle signals on Windows is to just listen for the
+//! `CTRL_C_EVENT` event. This is done by calling `SetConsoleCtrlHandler` with a callback function
+//! that iterates through a linked list of registered callbacks and calls them.
+
+use async_lock::OnceCell;
+use slab::Slab;
+
+use std::io::Result;
+use std::mem;
+use std::os::raw::c_int;
+use std::sync::Mutex;
+
+use super::libc::SIGINT;
+
+/// The ID of a signal handler.
+pub(crate) type SigId = usize;
+
+/// Register a handler into the global registry.
+///
+/// # Safety
+///
+/// This function is safe; it is only unsafe for consistency.
+pub(crate) unsafe fn register(
+    signal: c_int,
+    handler: impl Fn() + Send + Sync + 'static,
+) -> Result<SigId> {
+    // If this signal isn't SIGINT, then we can't register it.
+    if signal != SIGINT {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "unsupported signal",
+        ));
+    }
+
+    // Register the handler into the global registry.
+    Ok(Registry::get()?.register(handler))
+}
+
+/// Derigister a handler from the global registry.
+pub fn unregister(id: SigId) {
+    if let Ok(registry) = Registry::get() {
+        registry.unregister(id)
+    }
+}
+
+/// The global registry of signal handlers.
+struct Registry {
+    /// The list of signal handlers.
+    handlers: Mutex<Slab<Handler>>,
+}
+
+/// A closure that handles a signal.
+type Handler = Box<dyn Fn() + Send + Sync + 'static>;
+
+impl Registry {
+    /// Get the global instance of the registry.
+    fn get() -> Result<&'static Self> {
+        static REGISTRY: OnceCell<Registry> = OnceCell::new();
+
+        REGISTRY.get_or_try_init_blocking(|| {
+            // Register ourselves into the global registry.
+            let res = unsafe { SetConsoleCtrlHandler(Some(Self::handle_event), true as _) };
+
+            if res == 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+
+            Ok(Registry {
+                handlers: Mutex::new(Slab::new()),
+            })
+        })
+    }
+
+    /// Handle a console control event.
+    unsafe extern "system" fn handle_event(event: u32) -> BOOL {
+        // Make sure panics aren't transmitted across the FFI boundary.
+        struct AbortOnDrop;
+
+        impl Drop for AbortOnDrop {
+            fn drop(&mut self) {
+                std::process::abort();
+            }
+        }
+
+        let _abort_on_drop = AbortOnDrop;
+
+        // If the event is CTRL_C_EVENT, then we should handle it.
+        if event == CTRL_C_EVENT {
+            // Get the global registry.
+            let registry = match Self::get() {
+                Ok(registry) => registry,
+                Err(_) => return false as BOOL,
+            };
+
+            // Note that Windows runs these handlers in another thread, so there's no need to
+            // worry about deadlocks.
+            let handlers = registry.handlers.lock().unwrap_or_else(|e| e.into_inner());
+
+            for handler in handlers.iter() {
+                (handler.1)();
+            }
+
+            mem::forget(_abort_on_drop);
+            return true as BOOL;
+        }
+
+        mem::forget(_abort_on_drop);
+        false as BOOL
+    }
+
+    /// Register a handler for a signal.
+    fn register(&self, handler: impl Fn() + Send + Sync + 'static) -> usize {
+        self.handlers
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(Box::new(handler))
+    }
+
+    /// Unregister a handler for a signal.
+    fn unregister(&self, id: usize) {
+        self.handlers
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .try_remove(id);
+    }
+}
+
+// Bindings generated with windows-bindgen v0.49.0
+::windows_targets::link!("kernel32.dll" "system" fn SetConsoleCtrlHandler(handlerroutine : PHANDLER_ROUTINE, add : BOOL) -> BOOL);
+#[allow(clippy::upper_case_acronyms)]
+pub type BOOL = i32;
+pub const CTRL_C_EVENT: u32 = 0u32;
+#[allow(non_camel_case_types)]
+pub type PHANDLER_ROUTINE =
+    ::core::option::Option<unsafe extern "system" fn(ctrltype: u32) -> BOOL>;


### PR DESCRIPTION
Adds support for Windows using the `SetConsoleCtrlHandler` system call to listen for CTRL-C messages.

Closes #1