### PR TITLE
v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Version 0.2.1
+
+- Add support for the signalfd mechanism on Linux. (#5)
+- Add support for Windows. (#6)
+- Bump MSRV to 1.63. (#8)
+
+# Version 0.2.0
+
+- Initial release
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-signal"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 authors = ["John Nunley <jtnunley01@gmail.com>"]
 rust-version = "1.63"


### PR DESCRIPTION
- Add support for the signalfd mechanism on Linux. (#5)
- Add support for Windows. (#6)
- Bump MSRV to 1.63. (#8)