### PR TITLE
v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.2.3
+
+- Remove the `signalfd` backend, as it offered little to no advantages over the pipe-based backend and it didn't catch signals sometimes. (#20)
+
 # Version 0.2.2
 
 - Fix build error on Android. (#18)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-signal"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2018"
 authors = ["John Nunley <jtnunley01@gmail.com>"]
 rust-version = "1.63"


### PR DESCRIPTION
- Remove the `signalfd` backend, as it offered little to no advantages over the pipe-based backend and it didn't catch signals sometimes. (#20)