### PR TITLE
v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.2.5
+
+- Bump `async-io` to version 2.0.0. (#25)
+
 # Version 0.2.4
 
 - Add `LICENSE` files to this crate. (#23)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "async-signal"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2018"
-authors = ["John Nunley <jtnunley01@gmail.com>"]
+authors = ["John Nunley <dev@notgull.net>"]
 rust-version = "1.63"
 description = "Async signal handling"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
- Bump `async-io` to version 2.0.0. (#25)
