### PR TITLE
chore: Bump async-lock to 3.3.0, windows-sys to 0.52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ rustix = { version = "0.38.15", default-features = false, features = ["process",
 signal-hook-registry = "1.4.0"
 
 [target.'cfg(windows)'.dependencies]
-async-lock = "2.7.0"
+async-lock = "3.3.0"
 atomic-waker = "1.1.1"
 slab = "0.4.8"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48"
+version = "0.52"
 default-features = false
 features = [
     "Win32_Foundation",


### PR DESCRIPTION
The rationale was trying to cut down on the copious amount of duplicate versions in our dependency tree over here:
https://github.com/ruffle-rs/ruffle/actions/runs/8701668584/job/23864127408#step:5:12

Thank you for the consideration.