### PR TITLE
v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.2.6
+
+- Bump `windows-sys` to 0.52 and `async-io` to 3.3.0. (#27)
+
 # Version 0.2.5
 
 - Bump `async-io` to version 2.0.0. (#25)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-signal"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2018"
 authors = ["John Nunley <dev@notgull.net>"]
 rust-version = "1.63"


### PR DESCRIPTION
- Bump `windows-sys` to 0.52 and `async-io` to 3.3.0. (#27)
