### PR TITLE
v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.2.7
+
+- Remove an invalid category from `Cargo.toml`. (#33)
+
 # Version 0.2.6
 
 - Bump `windows-sys` to 0.52 and `async-io` to 3.3.0. (#27)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-signal"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2018"
 authors = ["John Nunley <dev@notgull.net>"]
 rust-version = "1.63"


### PR DESCRIPTION
- Remove an invalid category from `Cargo.toml`. (#33)
