### PR TITLE
docs: signals needs to be mut

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ use futures_lite::prelude::*;
 use signal_hook::low_level;
 
 // Register the signals we want to receive.
-let signals = Signals::new(&[
+let mut signals = Signals::new(&[
     Signal::Term,
     Signal::Quit,
     Signal::Int,


### PR DESCRIPTION
The `signals` variable in the example needs to be `mut` so that [`futures_lite::stream::StreamExt::next(&mut self)`](https://docs.rs/futures-lite/latest/futures_lite/stream/trait.StreamExt.html#method.next) can be invoked.