### PR TITLE
docs: fix clippy lint in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ use futures_lite::prelude::*;
 use signal_hook::low_level;
 
 // Register the signals we want to receive.
-let mut signals = Signals::new(&[
+let mut signals = Signals::new([
     Signal::Term,
     Signal::Quit,
     Signal::Int,


### PR DESCRIPTION
The readme example before this change resulted in this clippy warning:

```
warning: the borrowed expression implements the required traits
 --> examples/readme.rs:8:40
  |
8 |         let mut signals = Signals::new(&[Signal::Term, Signal::Quit, Signal::Int]).unwrap();
  |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `[Signal::Term, Signal::Quit, Signal::Int]`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
  = note: `#[warn(clippy::needless_borrows_for_generic_args)]` on by default
```