### PR TITLE
v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.2.9
+
+- Fix the `clippy::needless_borrows_for_generic_args` lint in the README
+  example. (#38)
+
 # Version 0.2.8
 
 - Update README.md to use a working example. (#35)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-signal"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2018"
 authors = ["John Nunley <dev@notgull.net>"]
 rust-version = "1.63"


### PR DESCRIPTION
- Fix the `clippy::needless_borrows_for_generic_args` lint in the README example. (#38)
